### PR TITLE
Remove the global envs from the manifest

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -29,9 +29,6 @@
   "bugs": {
     "url": "https://github.com/dappnode/DAppNodePackage-NEAR/issues"
   },
-  "globalEnvs": {
-    "all": true
-  },
   "backup": [
     {
       "name": "config",


### PR DESCRIPTION
This package does not use stakers UI, this content of the manifest provokes an error during the installation.
The error in the next:
```
Error: Command failed: docker-compose -f /usr/src/app/dnp_repo/near.dnp.dappnode.eth/docker-compose.yml up --no-start --remove-orphans <&-
Container DAppNodePackage-near.near.dnp.dappnode.eth  Creating
Container DAppNodePackage-wallet.near.dnp.dappnode.eth  Creating
Error response from daemon: invalid environment variable: =_DAPPNODE_GLOBAL_EXECUTION_CLIENT_PRATER

    at /usr/src/app/webpack:/@dappnode/dappmanager/src/utils/shell.ts:35:16
    at Generator.throw (<anonymous>)
    at rejected (/usr/src/app/index.js:400143:65)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

{
  "name": "near.dnp.dappnode.eth",
  "version": "/ipfs/QmbL5ZT8Uk15DxF1iWGyzn3f7CJBKbTiqhuHDoXjkQuqLu",
  "userSettings": {},
  "options": {
    "BYPASS_SIGNED_RESTRICTION": true
  }
}
```
In some dappnodes i had this issue and in other not.
