### PR TITLE
Revert "bump near/nearcore to 1.33.0-rc.1"

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "near.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "1.33.0-rc.1",
+  "upstreamVersion": "1.31.1",
   "upstreamRepo": "near/nearcore",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Reimagine your world.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: neard_image
       args:
-        UPSTREAM_VERSION: 1.33.0-rc.1
+        UPSTREAM_VERSION: 1.31.1
     volumes:
       - "near:/srv/near"
     restart: unless-stopped


### PR DESCRIPTION
Reverts dappnode/DAppNodePackage-NEAR#39 No docker tag associated