### PR TITLE
Fix+Update NEAR Wallet

### DIFF
--- a/neard_image/staking-ui/.gitignore
+++ b/neard_image/staking-ui/.gitignore
@@ -12,7 +12,6 @@
 /build
 
 # misc
-.DS_Store
 .env.local
 .env.development.local
 .env.test.local

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -5,21 +5,21 @@ FROM phusion/baseimage:jammy-1.0.1 as build
 ARG NODE_URL
 ENV NEAR_WALLET_ENV=mainnet
 ENV REACT_APP_NODE_URL=${NODE_URL}
-
+ENV NODE_MAJOR=16
 ## Test new install method for NodeJS from nodesource
 #RUN apt-get update
 #RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN NODE_MAJOR=16
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
  
 ##
+RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn/pubkey.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/yarn/pubkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 #RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
 #RUN bash /tmp/node_setup.sh
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
+
 RUN apt-get update -qq && apt-get install -y \
     nodejs \
     git

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM phusion/baseimage:0.11 as build
+FROM phusion/baseimage:jammy-1.0.1 as build
 
 ARG NODE_URL
 ENV NEAR_WALLET_ENV=mainnet

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -3,24 +3,23 @@
 FROM phusion/baseimage:jammy-1.0.1 as build
 
 ARG NODE_URL
+
 ENV NEAR_WALLET_ENV=mainnet
 ENV REACT_APP_NODE_URL=${NODE_URL}
 ENV NODE_MAJOR=16
-## Test new install method for NodeJS from nodesource
-#RUN apt-get update
-#RUN apt-get install -y ca-certificates curl gnupg
-RUN mkdir -p /etc/apt/keyrings
+
+## Removed deprecated Node install script replaced with current install instructions, and allows for Changing NodeJS Major Version between 16.x,18.x, 20.x, and 21.x by editing the above ENV variable NODE_MAJOR to the major version desired, 16, 18, 20, and 21.  Note: Versions 18.x and up are only available on Jammy and Focal based phusion/baseimage's; if reverting to Bionic 18.04 and earlier, Node version 16.x is the only compatible version. 
+# Download and install NodeJS GPG keys
+RUN mkdir -p /etc/apt/keyrings/yarn
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
  
-##
-RUN mkdir -p /etc/apt/keyrings/yarn
+## Upgrade Deprecated `apt-key` method of adding GPG keys
+# Download and install Yarn Package GPG keys
 RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn/pubkey.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/yarn/pubkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-#RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
-#RUN bash /tmp/node_setup.sh
-
+# Update with newly added sources for Yarn and NodeJS, install Git, Chosen NodeJS version and Yarn
 RUN apt-get update -qq && apt-get install -y \
     nodejs \
     git

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -6,10 +6,20 @@ ARG NODE_URL
 ENV NEAR_WALLET_ENV=mainnet
 ENV REACT_APP_NODE_URL=${NODE_URL}
 
-RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
-RUN bash /tmp/node_setup.sh
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
+## Test new install method for NodeJS from nodesource
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN NODE_MAJOR=16
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+ 
+##
+
+#RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
+#RUN bash /tmp/node_setup.sh
+#RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+#RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y \
     nodejs \
     git

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -33,7 +33,7 @@ RUN yarn install
 RUN NEAR_WALLET_ENV=mainnet REACT_APP_NODE_URL=${NODE_URL} yarn run build
 
 # ======================== EXECUTE ==================================
-FROM nginx:1.22.0-alpine
+FROM nginx:1.25.3-alpine
 COPY --from=build /near-wallet/packages/frontend/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -14,6 +14,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
  
 ##
+RUN mkdir -p /etc/apt/keyrings/yarn
 RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn/pubkey.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/yarn/pubkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -6,7 +6,7 @@ ARG NODE_URL
 ENV NEAR_WALLET_ENV=mainnet
 ENV REACT_APP_NODE_URL=${NODE_URL}
 
-RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_14.x"
+RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
 RUN bash /tmp/node_setup.sh
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list

--- a/wallet/Dockerfile
+++ b/wallet/Dockerfile
@@ -7,19 +7,19 @@ ENV NEAR_WALLET_ENV=mainnet
 ENV REACT_APP_NODE_URL=${NODE_URL}
 
 ## Test new install method for NodeJS from nodesource
-RUN apt-get update
-RUN apt-get install -y ca-certificates curl gnupg
+#RUN apt-get update
+#RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN NODE_MAJOR=16
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
  
 ##
 
 #RUN curl -o /tmp/node_setup.sh "https://deb.nodesource.com/setup_16.x"
 #RUN bash /tmp/node_setup.sh
-#RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-#RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y \
     nodejs \
     git


### PR DESCRIPTION
The near wallet is and has been broken for the most part for as long as this package has existed, and the whole UI needs to be rebuilt, all package.json depedencies are very out of date and likely not safe.  THis will alsno not work with Node14.x which is deprecated so Im bumping to 16.x to see how it works and mayve bump it even higher possibly to 18.x when i go over the build and repackage the app with proper dependencies, but as is the wallet doesnt work and doesnt need to work, it provides no benefits over other wallets, this is really just a a NEAR node with RPC functionality.