### PR TITLE
ci: use dappnode-build-hash reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - "main"
+    paths-ignore: ["README.md"]
+
+jobs:
+  build:
+    uses: dappnode/workflows/.github/workflows/dappnode-build-hash.yml@master
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,37 +1,25 @@
 name: "Main"
 on:
-  pull_request:
   push:
     branches:
-      - "master"
       - "main"
       - "v[0-9]+.[0-9]+.[0-9]+"
     paths-ignore:
       - "README.md"
+  workflow_dispatch:
+  repository_dispatch:
 
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    name: Build test
-    if: github.event_name != 'push'
-    steps:
-      - uses: actions/checkout@v6
-      - run: npx @dappnode/dappnodesdk build --provider remote
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
-          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
       - name: Publish
         run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
-          PINATA_SECRET_API_KEY: ${{ secrets.PINATA_SECRET_API_KEY }}
           DEVELOPER_ADDRESS: "0xf35960302a07022aba880dffaec2fdd64d5bf1c1"


### PR DESCRIPTION
## Context

This repo'\''s build pipeline (an inlined `build-test` step with `--skip_save`) never pinned to IPFS or posted a comment on PRs, so tropibot bumps had no installable artifact for testers.

## Approach

- `.github/workflows/build.yml` (new) — thin stub calling `dappnode-build-hash@master` with `secrets: inherit`. Triggers on `push` (non-default branch) and `workflow_dispatch` only.
- `.github/workflows/main.yml` — slimmed to the release job only. `build-test` removed; `actions/checkout` upgraded to v7; Node 24 with `actions/setup-node@v6`. Dropped the redundant `if:` condition. Added `repository_dispatch` to triggers.

## Test instructions

1. Push a commit to a non-default branch (or open a test PR).
2. Verify the `Build` workflow runs once and posts a comment with an IPFS install link and hash tagged `(by dappnodebot/build-action)` and authored by `tropibot[bot]`.
3. After merge to main, the `Main` workflow should run the release.